### PR TITLE
More buffer size adjustments and fixed config file reads.

### DIFF
--- a/Build/Makefile
+++ b/Build/Makefile
@@ -77,7 +77,6 @@ OURCFLAGS=$(debug) \
 	-Wno-sign-compare \
 	-Wno-type-limits \
 	-Wno-unused-but-set-parameter \
-	-Wno-format \
 	\
 	-fno-pic \
 	\

--- a/Build/src/build.c
+++ b/Build/src/build.c
@@ -2774,7 +2774,7 @@ int CheckAnimations(long iNum)                                        // wxvc
 
 void overheadeditor(void)
 {
-	char buffer[80], *dabuffer, ch;
+	char buffer[270], *dabuffer, ch;
 	long i, j, k, m=0, mousxplc, mousyplc, firstx=0, firsty=0, oposz, col;
 	long templong, templong1, templong2, doubvel;
 	long startwall, endwall, dax, day, daz, x1, y1, x2, y2, x3, y3, x4, y4;
@@ -6238,7 +6238,7 @@ long menuselect(void)
 {
 	int listsize;
 	long i, j, topplc;
-	char ch, buffer[78], *sb;
+	char ch, buffer[83], *sb;
 	CACHE1D_FIND_REC *dir;
 
 	int bakpathsearchmode = pathsearchmode;

--- a/Source/config.c
+++ b/Source/config.c
@@ -629,17 +629,21 @@ int32 CONFIG_ReadSetup( void )
    if (SafeFileExists(setupfilename))
        scripthandle = SCRIPT_Load(setupfilename);
 
-   if (scripthandle < 0) return -1;
+   if (scripthandle < 0)
+	   return -1;
 
       SCRIPT_GetNumber( scripthandle, "Screen Setup", "ScreenMode",&ScreenMode);
       SCRIPT_GetNumber( scripthandle, "Screen Setup", "ScreenWidth",&ScreenWidth);
       SCRIPT_GetNumber( scripthandle, "Screen Setup", "ScreenHeight",&ScreenHeight);
-      SCRIPT_GetNumber( scripthandle, "Screen Setup", "ScreenBPP", &ScreenBPP);
-      if (ScreenBPP < 8) ScreenBPP = 8;
-
-      gs.SetHighres = 0;
-      if (ScreenBPP > 8)
-          gs.SetHighres = 1;
+	  if (!SCRIPT_GetNumber( scripthandle, "Screen Setup", "ScreenBPP", &ScreenBPP))
+	  {
+		// If ScreenBPP was set/changed...
+		if (ScreenBPP < 8)
+		  ScreenBPP = 8;
+	    gs.SetHighres = 0;
+        if (ScreenBPP > 8)
+		  gs.SetHighres = 1;
+	  }
 
 #ifdef RENDERTYPEWIN
       SCRIPT_GetNumber( scripthandle, "Screen Setup", "MaxRefreshFreq", (int32*)&maxrefreshfreq);
@@ -652,63 +656,106 @@ int32 CONFIG_ReadSetup( void )
 
       SCRIPT_GetNumber( scripthandle, "Screen Setup", "GLFovscreen", &glfovscreen);
       SCRIPT_GetNumber( scripthandle, "Screen Setup", "GLWidescreen", &glwidescreen);
-      SCRIPT_GetNumber( scripthandle, "Screen Setup", "GLVSync", &dummy);
-      vsync = dummy;
+	  if (!SCRIPT_GetNumber( scripthandle, "Screen Setup", "GLVSync", &dummy))
+	  {
+		// If vsync was set/changed...
+		vsync = dummy;
+	  }
 
       SCRIPT_GetNumber( scripthandle, "Screen Setup", "HighTiles", &usehightile);
       SCRIPT_GetNumber( scripthandle, "Screen Setup", "HighModels", &usemodels);
 
       SCRIPT_GetNumber( scripthandle, "Screen Setup", "Usegoodalpha", &usegoodalpha);
-      SCRIPT_GetNumber( scripthandle, "Screen Setup", "LcdMonitor",&dummy);
-      LcdMon = dummy;
+      if (!SCRIPT_GetNumber( scripthandle, "Screen Setup", "LcdMonitor",&dummy))
+	  {
+		// If LcdMon was set/changed...
+		LcdMon = dummy;
+	  }
+      
 
       SCRIPT_GetNumber( scripthandle, "Sound Setup", "FXDevice",&FXDevice);
       SCRIPT_GetNumber( scripthandle, "Sound Setup", "MusicDevice",&MusicDevice);
-      SCRIPT_GetNumber( scripthandle, "Sound Setup", "FXVolume",&FXVolume);
-      gs.SoundVolume = FXVolume;
-      SCRIPT_GetNumber( scripthandle, "Sound Setup", "MusicVolume",&MusicVolume);
-      gs.MusicVolume = MusicVolume;
+      if (!SCRIPT_GetNumber( scripthandle, "Sound Setup", "FXVolume",&FXVolume))
+	  {
+		// If FXVolume was set/changed...
+		gs.SoundVolume = FXVolume;
+	  }
+      if (!SCRIPT_GetNumber( scripthandle, "Sound Setup", "MusicVolume",&MusicVolume))
+	  {
+		// If MusicVolume was set/changed...
+		gs.MusicVolume = FXVolume;
+	  }
 
       SCRIPT_GetNumber( scripthandle, "Sound Setup", "NumVoices",&NumVoices);
       SCRIPT_GetNumber( scripthandle, "Sound Setup", "NumChannels",&NumChannels);
       SCRIPT_GetNumber( scripthandle, "Sound Setup", "NumBits",&NumBits);
       SCRIPT_GetNumber( scripthandle, "Sound Setup", "MixRate",&MixRate);
-      SCRIPT_GetNumber( scripthandle, "Sound Setup", "ReverseStereo",&dummy);
-      gs.FlipStereo = dummy;
-      if (gs.FlipStereo) gs.FlipStereo = 1;
+      if (!SCRIPT_GetNumber( scripthandle, "Sound Setup", "ReverseStereo",&dummy))
+	  {
+		// If ReverseStereo was set/changed...
+        gs.FlipStereo = dummy;
+        if (gs.FlipStereo) gs.FlipStereo = 1;
+	  }
 
       SCRIPT_GetNumber( scripthandle, "Setup", "ForceSetup",&ForceSetup);
       SCRIPT_GetNumber( scripthandle, "Controls","UseMouse",&UseMouse);
       SCRIPT_GetNumber( scripthandle, "Controls","UseJoystick",&UseJoystick);
 
-      SCRIPT_GetNumber( scripthandle, "SwpOptions","WeaponSwitch",&dummy);
-      gs.WeaponSwitch = dummy;
+	  if (!SCRIPT_GetNumber( scripthandle, "SwpOptions","WeaponSwitch",&dummy))
+	  {
+		// If WeaponSwitch was set/changed...
+        gs.WeaponSwitch = dummy;
+	  }
 
-      SCRIPT_GetNumber( scripthandle, "SwpOptions","SwpUseDarts",&dummy);
-      gs.UseDarts = dummy;
+	  if (!SCRIPT_GetNumber( scripthandle, "SwpOptions","SwpUseDarts",&dummy))
+	  {
+		// If SwpUseDarts was set/changed...
+        gs.UseDarts = dummy;
+	  }
 
-      SCRIPT_GetNumber( scripthandle, "SwpOptions","SwapYinyang",&dummy);
-      gs.SwapYinyang = dummy;
+	  if (!SCRIPT_GetNumber( scripthandle, "SwpOptions","SwapYinyang",&dummy))
+	  {
+		// If SwapYinyang was set/changed...
+        gs.SwapYinyang = dummy;
+	  }
 
-      SCRIPT_GetNumber( scripthandle, "SwpOptions","ShowTEN",&dummy);
-      gs.ShowTEN = dummy;
+	  if (!SCRIPT_GetNumber( scripthandle, "SwpOptions","ShowTEN",&dummy))
+	  {
+		// If ShowTEN was set/changed...
+        gs.ShowTEN = dummy;
+	  }
 
-      SCRIPT_GetNumber( scripthandle, "SwpOptions","AutoSaveGame",&dummy);
-      Autosave = dummy;
+	  if (!SCRIPT_GetNumber( scripthandle, "SwpOptions","AutoSaveGame",&dummy))
+	  {
+		// If AutoSaveGame was set/changed...
+        Autosave = dummy;
+	  }
 
-      SCRIPT_GetNumber( scripthandle, "SwpOptions","RandomMusic",&dummy);
-      RandomMusic = dummy;
+	  if (!SCRIPT_GetNumber( scripthandle, "SwpOptions","RandomMusic",&dummy))
+	  {
+		// If RandomMusic was set/changed...
+        RandomMusic = dummy;
+	  }
 
-      SCRIPT_GetNumber( scripthandle, "SwpOptions","SwpNinjaHack",&dummy);
-      gs.UseNinjaHack = dummy;
+	  if (!SCRIPT_GetNumber( scripthandle, "SwpOptions","SwpNinjaHack",&dummy))
+	  {
+		// If SwpNinjaHack was set/changed...
+        gs.UseNinjaHack = dummy;
+	  }
 
-      SCRIPT_GetNumber( scripthandle, "SwpOptions","SwpCarHack",&dummy);
-      gs.UseCarHack = dummy;
+	  if (!SCRIPT_GetNumber( scripthandle, "SwpOptions","SwpCarHack",&dummy))
+	  {
+		// If SwpCarHack was set/changed...
+        gs.UseCarHack = dummy;
+	  }
 
-      SCRIPT_GetNumber( scripthandle, "SwpOptions","MenuTextColor",&dummy);
-      if (dummy < 0 || dummy > 14)
-          dummy = 5;
-      gs.MenuTextColor = dummy;
+	  if (!SCRIPT_GetNumber( scripthandle, "SwpOptions","MenuTextColor",&dummy))
+	  {
+		// If MenuTextColor was set/changed...
+        if (dummy < 0 || dummy > 14)
+            dummy = 5;
+        gs.MenuTextColor = dummy;
+	  }
 
       dummy = 0;
       SCRIPT_GetNumber( scripthandle, "SwpOptions", "MiniHudType",&dummy);
@@ -734,10 +781,13 @@ int32 CONFIG_ReadSetup( void )
           SCRIPT_GetString( scripthandle, "Network", buf, IPAddressArg[i]);
           }
 
-      SCRIPT_GetNumber(scripthandle, "Network", "LastIpUsed", &dummy);
-      if (IPAddressArg[dummy] == NULL)
-          dummy = 0;
-      LastIpUsed = dummy;
+	  if (!SCRIPT_GetNumber( scripthandle, "Network", "LastIpUsed", &dummy))
+	  {
+		// If LastIpUsed was set/changed...
+        if (IPAddressArg[dummy] == NULL)
+            dummy = 0;
+        LastIpUsed = dummy;
+	  }
 
    ReadGameSetup(scripthandle);
    gs.BorderMem = gs.BorderNum;

--- a/Source/jnstub.c
+++ b/Source/jnstub.c
@@ -2269,7 +2269,7 @@ ExtGetSpriteCaption(short spritenum)
     {
     SPRITEp sp = &sprite[spritenum];
     char* p = "";
-    char name[64];
+    char name[66];
     char tp[30];
     char multi_str[30] = "";
     SHORT data;

--- a/Source/menus.c
+++ b/Source/menus.c
@@ -151,7 +151,6 @@ extern BOOL cdvalid, enabled;
 short TimeLimitTable[9] = {0,3,5,10,15,20,30,45,60};
 
 short QuickLoadNum = -1;
-char QuickLoadDescrDialog[32];
 BOOL QuickSaveMode = FALSE;
 BOOL SavePrompt = FALSE;
 
@@ -1808,6 +1807,7 @@ BOOL MNU_QuickLoadCustom(UserCall call, MenuItem_p item)
     extern BOOL DrawScreen;
     extern long Autotick;
     long ret;
+	char QuickLoadDescrDialog[89];
 
     if (cust_callback == NULL)
     {
@@ -2779,7 +2779,7 @@ BOOL MNU_LoadSaveDraw(UserCall call, MenuItem_p item)
         if (i == game_num && MenuInputMode && !SavePrompt)
         {
             static BOOL cur_show;
-            char tmp[sizeof(SaveGameDescr[0])];
+            char tmp[1+sizeof(SaveGameDescr[0])];
 
             //cur_show ^= 1;
 	        cur_show = (totalclock & 32);

--- a/Source/swconfig.c
+++ b/Source/swconfig.c
@@ -144,6 +144,7 @@ void ReadGameSetup( int32 scripthandle )
         SCRIPT_GetString( scripthandle, "Network",ds,WangBangMacro[dummy]);
         }
 
+	dummy = -1; // MH 20190105 - Was missing this assignment
     SCRIPT_GetNumber( scripthandle, "Network", "NetGameType",&dummy);
     if (dummy != -1) gs.NetGameType = dummy;
 
@@ -183,8 +184,11 @@ void ReadGameSetup( int32 scripthandle )
     SCRIPT_GetNumber( scripthandle, "Network", "NetNuke",&dummy);
     if (dummy != -1) gs.NetNuke = dummy;
 
-    SCRIPT_GetString( scripthandle, "Options","Rooster",gs.Password);
-    DecodePassword(gs.Password);
+    if (!SCRIPT_GetString( scripthandle, "Options","Rooster",gs.Password))
+	{
+	  // If Rooster was set/changed...
+      DecodePassword(gs.Password);
+	}
 
     // option stuff
     dummy = -1;
@@ -235,7 +239,6 @@ void ReadGameSetup( int32 scripthandle )
     SCRIPT_GetNumber( scripthandle, "Controls", "MouseAiming",&dummy);
     if (dummy != -1) gs.MouseAimingType = dummy;
 
-    dummy = -1;
     dummy = -1;
     SCRIPT_GetNumber( scripthandle, "Options", "Voxels",&dummy);
     if (dummy != -1) usevoxels = dummy;


### PR DESCRIPTION
As well as fixing a few more buffer sizes, partial config file reads could cause crashes in the menus when a setting wasn't present in the config file and setting it required post processing by having the script read call set a "dummy" variable instead of the current actual setting.

In such cases, the script read call did not modify the result variable ("dummy") but in many cases the post processing logic didn't **check** whether it had or not, and would blindly use whatever random value was in the dummy variable to begin with. If the value eventually written back to the setting was an index into a table, this would normally result in a segfault when the table was accessed.